### PR TITLE
Changed $client visibility

### DIFF
--- a/src/Parsian.php
+++ b/src/Parsian.php
@@ -38,7 +38,7 @@ class Parsian
     /**
      * @var \SoapClient
      */
-    private $client;
+    protected $client;
 
     /**
      * @param  string  $pin


### PR DESCRIPTION
Visibility of $client property has been changed to "protected" in order to provide access to the property inside descendant of the class.